### PR TITLE
table hierarchy and samples id

### DIFF
--- a/widgets/widget.metagenome_analysis.js
+++ b/widgets/widget.metagenome_analysis.js
@@ -1640,14 +1640,29 @@
 	var c = stm.DataStore.dataContainer[widget.selectedContainer];
 
 	var matrix = jQuery.extend(true, {}, data ? data : stm.DataStore.dataContainer[widget.selectedContainer].matrix);
-	var tableHeaders = [ c.parameters.displayLevel ];
+	var l = c.hierarchy[Retina.keys(c.hierarchy)[0]].length;
+	var tableHeaders = [];
+	for (var i=0; i<l; i++) {
+	    tableHeaders.push(document.getElementById('displayLevelSelect').options[i].value);
+	}
 	for (var i=0; i<matrix.cols.length; i++) {
 	    tableHeaders.push(matrix.cols[i]);
 	}
 
 	var tableData = [];
 	for (var i=0; i<matrix.rows.length; i++) {
-	    var row = [ forExport ? matrix.rows[i] : '<a href="#" onclick="Retina.WidgetInstances.metagenome_analysis[1].graphCallback({\'cellValue\': \''+matrix.rows[i]+'\'})">'+matrix.rows[i]+'</a>' ];
+	    var row = [];
+	    for (var h=0; h<l; h++) {
+		if (forExport) {
+		    row.push(c.hierarchy[matrix.rows[i]][h]);
+		} else {
+		    if (h == l-1 && h < document.getElementById('displayLevelSelect').options.length - 1) {
+			row.push('<a href="#" onclick="Retina.WidgetInstances.metagenome_analysis[1].graphCallback({\'cellValue\': \''+c.hierarchy[matrix.rows[i]][h]+'\'})">'+c.hierarchy[matrix.rows[i]][h]+'</a>');
+		    } else {
+			row.push(c.hierarchy[matrix.rows[i]][h]);
+		    }
+		}
+	    }
 	    for (var h=0; h<matrix.data[i].length; h++) {
 		row.push(matrix.data[i][h]);
 	    }

--- a/widgets/widget.metagenome_library.js
+++ b/widgets/widget.metagenome_library.js
@@ -59,8 +59,10 @@
 
 	var lib = stm.DataStore.library[widget.id];
 	
-	html = ['<h3>library '+widget.id+'<div class="btn-group pull-right"><a href="?mgpage=project&project='+lib.project[0]+'" class="btn">study</a><a href="?mgpage=sample&sample='+lib.sample[0]+'" class="btn">sample</button><a href="?mgpage=overview&metagenome='+lib.metagenome[0]+'" class="btn">metagenome</a></div></h3>'];
-
+	html = ['<h3>library '+widget.id+'<div class="btn-group pull-right"><a href="?mgpage=project&project='+lib.project[0]+'" class="btn">study</a><a href="?mgpage=sample&sample='+lib.sample[0]+'" class="btn">sample</button>'];
+	if (lib.metagenome) {
+	    html.push('<a href="?mgpage=overview&metagenome='+lib.metagenome[0]+'" class="btn">metagenome</a></div></h3>');
+	}
 	
 	html.push('<table>');
 	var k = Retina.keys(lib.metadata).sort();

--- a/widgets/widget.metagenome_metazen2.js
+++ b/widgets/widget.metagenome_metazen2.js
@@ -930,6 +930,15 @@
 	var widget = this;
 
 	widget.metadata = {};
+
+	var s = document.getElementById('sample').firstChild;
+	for (var i=0; i<s.rows.length; i++) {
+	    if (i==0) {
+		s.rows[i].cells[0].innerHTML = "";
+	    } else {
+		s.rows[i].cells[0].innerHTML = i;
+	    }
+	}
 	
 	var tables = [];
 	tables.push( { "name": "project", "data": widget.metadataTemplate.project.project } );
@@ -1051,11 +1060,19 @@
 	    d.samples = d.samples.sort(function (a,b) { return a.data.hasOwnProperty('sample_name') ? a.data.sample_name.value.localeCompare(b.data.sample_name.value) : -1 });
 	    
 	    // iterate over the samples
+	    document.getElementById('sample').firstChild.rows[0].cells[0].innerHTML = "ID";
 	    for (var h=0; h<d.samples.length; h++) {
 		
 		// fill in the sample sheet
 		var s = d.samples[h];
-		widget.setCell('sample', 'sample_id', s.id);
+		document.getElementById('sample').firstChild.rows[h + 1].cells[0].innerHTML = s.id;
+		if (! widget.metadata.hasOwnProperty('sample')) {
+		    widget.metadata.sample = {};
+		}
+		if (! widget.metadata.sample.hasOwnProperty('id')) {
+		    widget.metadata.sample.id = [];
+		}
+		widget.metadata.sample.id.push(s.id);
 		fields = Retina.keys(s.data);
 		for (var i=0; i<fields.length; i++) {
 		    if (fields[i] == "sample_id") {


### PR DESCRIPTION
- tabes on the analysis page can now show the full hierarchy
- metazen now shows readonly sample id when importing from a project